### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ the directory from the last blockpassword.
 If you are creating a branch, then continue.
 If it is because of incorrect password, then unmount and retry (otherwise you can overwrite the correct entry).
 
-* `No entries loaded for auxilary branch, maybe need better password` - 
+* `No entries loaded for auxiliary branch, maybe need better password` - 
 can't load the directory for non-last blockpassword.
 chaoticfs aborts in this case.
 


### PR DESCRIPTION
vi, I've corrected a typographical error in the documentation of the [chaoticfs](https://github.com/vi/chaoticfs) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.